### PR TITLE
Add service and controller tests

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -139,6 +139,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
 
         <!-- Spring Cache -->
         <dependency>

--- a/backend/src/test/DatabaseConnectionTest.java
+++ b/backend/src/test/DatabaseConnectionTest.java
@@ -10,9 +10,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest(properties = {
-        "spring.datasource.url=jdbc:postgresql://localhost:5432/saude_db",
-        "spring.datasource.username=postgres",
-        "spring.datasource.password=postgres"
+        "spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "spring.flyway.enabled=false"
 })
 class DatabaseConnectionTest {
 

--- a/backend/src/test/java/com/sistemadesaude/backend/atendimento/controller/AtendimentoControllerTest.java
+++ b/backend/src/test/java/com/sistemadesaude/backend/atendimento/controller/AtendimentoControllerTest.java
@@ -1,0 +1,64 @@
+package com.sistemadesaude.backend.atendimento.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sistemadesaude.backend.atendimento.dto.AtendimentoDTO;
+import com.sistemadesaude.backend.atendimento.service.AtendimentoPdfService;
+import com.sistemadesaude.backend.atendimento.service.AtendimentoService;
+import com.sistemadesaude.backend.verdepois.repository.LogSistemaRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(AtendimentoController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class AtendimentoControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private AtendimentoService service;
+    @MockBean
+    private AtendimentoPdfService pdfService;
+    @MockBean
+    private LogSistemaRepository logRepo;
+
+    @Test
+    void criarAtendimentoRetornaSucesso() throws Exception {
+        AtendimentoDTO dto = AtendimentoDTO.builder()
+                .id("1").pacienteId("p1").cid10("A00")
+                .dataHora(LocalDateTime.now()).build();
+        when(service.criarAtendimento(any())).thenReturn(dto);
+
+        mockMvc.perform(post("/api/atendimentos")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+    }
+
+    @Test
+    void buscarPorIdRetornaAtendimento() throws Exception {
+        AtendimentoDTO dto = AtendimentoDTO.builder().id("1").pacienteId("p1").cid10("A00").build();
+        when(service.buscarPorId("1")).thenReturn(dto);
+
+        mockMvc.perform(get("/api/atendimentos/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value("1"));
+    }
+}

--- a/backend/src/test/java/com/sistemadesaude/backend/atendimento/service/AtendimentoServiceImplTest.java
+++ b/backend/src/test/java/com/sistemadesaude/backend/atendimento/service/AtendimentoServiceImplTest.java
@@ -1,0 +1,84 @@
+package com.sistemadesaude.backend.atendimento.service;
+
+import com.sistemadesaude.backend.atendimento.dto.AtendimentoDTO;
+import com.sistemadesaude.backend.atendimento.entity.Atendimento;
+import com.sistemadesaude.backend.atendimento.mapper.AtendimentoMapper;
+import com.sistemadesaude.backend.atendimento.repository.AtendimentoRepository;
+import com.sistemadesaude.backend.verdepois.exception.ResourceNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AtendimentoServiceImplTest {
+
+    @Mock
+    private AtendimentoRepository repository;
+
+    private AtendimentoMapper mapper = Mappers.getMapper(AtendimentoMapper.class);
+
+    private AtendimentoServiceImpl service;
+
+    @BeforeEach
+    void setup() {
+        service = new AtendimentoServiceImpl(repository, mapper);
+    }
+
+    @Test
+    void criarAtendimentoGeraDataQuandoNecessario() {
+        AtendimentoDTO dto = AtendimentoDTO.builder()
+                .pacienteId("1")
+                .cid10("A00")
+                .build();
+
+        Atendimento saved = Atendimento.builder()
+                .id("2")
+                .pacienteId("1")
+                .cid10("A00")
+                .dataHora(LocalDateTime.now())
+                .build();
+
+        when(repository.save(any(Atendimento.class))).thenReturn(saved);
+
+        AtendimentoDTO result = service.criarAtendimento(dto);
+        assertNotNull(result.getDataHora());
+        verify(repository).save(any(Atendimento.class));
+    }
+
+    @Test
+    void buscarPorIdInexistenteLancaExcecao() {
+        when(repository.findById("x")).thenReturn(Optional.empty());
+        assertThrows(ResourceNotFoundException.class, () -> service.buscarPorId("x"));
+    }
+
+    @Test
+    void atualizarAtendimentoPersisteAlteracoes() {
+        Atendimento existente = Atendimento.builder()
+                .id("1").pacienteId("p1").cid10("B00").build();
+        when(repository.findById("1")).thenReturn(Optional.of(existente));
+
+        Atendimento salvo = Atendimento.builder()
+                .id("1").pacienteId("p1").cid10("B01").build();
+        when(repository.save(any(Atendimento.class))).thenReturn(salvo);
+
+        AtendimentoDTO dto = AtendimentoDTO.builder().cid10("B01").build();
+        AtendimentoDTO result = service.atualizarAtendimento("1", dto);
+        assertEquals("B01", result.getCid10());
+    }
+
+    @Test
+    void excluirAtendimentoNaoExistenteLancaExcecao() {
+        when(repository.existsById("99")).thenReturn(false);
+        assertThrows(ResourceNotFoundException.class, () -> service.excluirAtendimento("99"));
+    }
+}

--- a/backend/src/test/java/com/sistemadesaude/backend/paciente/controller/PacienteControllerTest.java
+++ b/backend/src/test/java/com/sistemadesaude/backend/paciente/controller/PacienteControllerTest.java
@@ -1,0 +1,54 @@
+package com.sistemadesaude.backend.paciente.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sistemadesaude.backend.paciente.dto.PacienteDTO;
+import com.sistemadesaude.backend.paciente.dto.PacienteListDTO;
+import com.sistemadesaude.backend.paciente.service.PacienteService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(PacienteController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class PacienteControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private PacienteService service;
+
+    @Test
+    void criarPacienteRetornaCreated() throws Exception {
+        PacienteDTO dto = PacienteDTO.builder().id(1L).nomeCompleto("Fulano").build();
+        when(service.criarPaciente(any())).thenReturn(dto);
+
+        mockMvc.perform(post("/api/pacientes")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(1L));
+    }
+
+    @Test
+    void buscarPacientePorIdNaoEncontradoRetorna404() throws Exception {
+        when(service.buscarPacientePorId(5L)).thenThrow(new com.sistemadesaude.backend.verdepois.exception.ResourceNotFoundException("nao"));
+
+        mockMvc.perform(get("/api/pacientes/5"))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/backend/src/test/java/com/sistemadesaude/backend/paciente/service/PacienteServiceImplTest.java
+++ b/backend/src/test/java/com/sistemadesaude/backend/paciente/service/PacienteServiceImplTest.java
@@ -1,0 +1,103 @@
+package com.sistemadesaude.backend.paciente.service;
+
+import com.sistemadesaude.backend.paciente.dto.PacienteDTO;
+import com.sistemadesaude.backend.paciente.dto.PacienteListDTO;
+import com.sistemadesaude.backend.paciente.entity.Paciente;
+import com.sistemadesaude.backend.paciente.mapper.PacienteMapper;
+import com.sistemadesaude.backend.paciente.repository.PacienteRepository;
+import com.sistemadesaude.backend.verdepois.exception.BusinessException;
+import com.sistemadesaude.backend.verdepois.exception.ResourceNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PacienteServiceImplTest {
+
+    @Mock
+    private PacienteRepository repository;
+
+    private PacienteMapper mapper = Mappers.getMapper(PacienteMapper.class);
+
+    private PacienteServiceImpl service;
+
+    @BeforeEach
+    void setup() {
+        service = new PacienteServiceImpl(repository, mapper);
+    }
+
+    @Test
+    void criarPacienteSalvaEntidade() {
+        PacienteDTO dto = PacienteDTO.builder()
+                .nomeCompleto("Fulano")
+                .cpf("123")
+                .cns("321")
+                .build();
+        Paciente saved = Paciente.builder()
+                .id(1L)
+                .nomeCompleto("Fulano")
+                .cpf("123")
+                .cns("321")
+                .build();
+
+        when(repository.existsByCpf("123")).thenReturn(false);
+        when(repository.existsByCns("321")).thenReturn(false);
+        when(repository.save(any(Paciente.class))).thenReturn(saved);
+
+        PacienteDTO result = service.criarPaciente(dto);
+
+        assertEquals(1L, result.getId());
+        ArgumentCaptor<Paciente> captor = ArgumentCaptor.forClass(Paciente.class);
+        verify(repository).save(captor.capture());
+        assertEquals("Fulano", captor.getValue().getNomeCompleto());
+    }
+
+    @Test
+    void criarPacienteComCpfDuplicadoDisparaExcecao() {
+        PacienteDTO dto = PacienteDTO.builder().cpf("123").build();
+        when(repository.existsByCpf("123")).thenReturn(true);
+        assertThrows(BusinessException.class, () -> service.criarPaciente(dto));
+    }
+
+    @Test
+    void buscarPacientePorIdInexistenteLancaExcecao() {
+        when(repository.findById(5L)).thenReturn(Optional.empty());
+        assertThrows(ResourceNotFoundException.class, () -> service.buscarPacientePorId(5L));
+    }
+
+    @Test
+    void excluirPacienteNaoEncontradoLancaExcecao() {
+        when(repository.existsById(9L)).thenReturn(false);
+        assertThrows(ResourceNotFoundException.class, () -> service.excluirPaciente(9L));
+    }
+
+    @Test
+    void buscarPacientesPorNomeRetornaLista() {
+        Paciente pac1 = Paciente.builder().id(1L).nomeCompleto("Ana").build();
+        Paciente pac2 = Paciente.builder().id(2L).nomeCompleto("Anabel").build();
+        when(repository.findByNomeCompletoContainingIgnoreCase("Ana"))
+                .thenReturn(Arrays.asList(pac1, pac2));
+
+        List<PacienteListDTO> lista = service.buscarPacientesPorNome("Ana");
+        assertEquals(2, lista.size());
+        assertEquals("Ana", lista.get(0).getNomeCompleto());
+    }
+
+    @Test
+    void verificarVulnerabilidadeAnalisaCampos() {
+        Paciente pac = Paciente.builder().id(1L).acamado(true).build();
+        when(repository.findById(1L)).thenReturn(Optional.of(pac));
+        assertTrue(service.verificarVulnerabilidade(1L));
+    }
+}

--- a/backend/src/test/resources/application-test.properties
+++ b/backend/src/test/resources/application-test.properties
@@ -1,0 +1,5 @@
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
+spring.datasource.driver-class-name=org.h2.Driver
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.flyway.enabled=false


### PR DESCRIPTION
## Summary
- add Mockito for tests
- update database test to use H2
- configure test application properties
- add unit tests for PacienteServiceImpl and AtendimentoServiceImpl
- add controller tests for PacienteController and AtendimentoController

## Testing
- `mvn test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6876c53210b883258b19bd7769f8e849