### PR TITLE
Add docker-compose and fix env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,20 +1,14 @@
-diff --git a/.env.example b/.env.example
-index 4ca9222015cda6a149b3f19672f457e709f00160..8545fa0ad7803ee3c7183372f2ff11418de52ecf 100644
---- a/.env.example
-+++ b/.env.example
-@@ -1,14 +1,15 @@
- # .env.example
+# .env.example
 
- # PostgreSQL
- DB_HOST=localhost
- DB_PORT=5432
- DB_NAME=cidade_saude_db
- DB_USER=cidade_user
- DB_PASS=cidade_pass
+# PostgreSQL
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=cidade_saude_db
+DB_USER=cidade_user
+DB_PASS=cidade_pass
 
- # Backend
- SPRING_PORT=5011
+# Backend
+SPRING_PORT=5011
 
- # Frontend
-+# Base URL para as chamadas da aplicação frontend
- VITE_API_BASE_URL=http://localhost:5011
+# Frontend
+VITE_API_BASE_URL=http://localhost:5011

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,44 @@
+version: '3.8'
+
+services:
+  db:
+    image: postgres:15
+    restart: always
+    ports:
+      - "${DB_PORT:-5432}:5432"
+    environment:
+      POSTGRES_DB: ${DB_NAME:-cidade_saude_db}
+      POSTGRES_USER: ${DB_USER:-cidade_user}
+      POSTGRES_PASSWORD: ${DB_PASS:-cidade_pass}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  backend:
+    build:
+      context: ./backend
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/${DB_NAME:-cidade_saude_db}
+      SPRING_DATASOURCE_USERNAME: ${DB_USER:-cidade_user}
+      SPRING_DATASOURCE_PASSWORD: ${DB_PASS:-cidade_pass}
+      SERVER_PORT: ${SPRING_PORT:-5011}
+      SPRING_PROFILES_ACTIVE: dev
+    ports:
+      - "${SPRING_PORT:-5011}:${SPRING_PORT:-5011}"
+    depends_on:
+      - db
+
+  frontend:
+    image: node:18
+    working_dir: /app
+    volumes:
+      - ./frontend:/app
+    command: sh -c "npm install && npm run dev -- --host"
+    ports:
+      - "5173:5173"
+    environment:
+      VITE_API_BASE_URL: ${VITE_API_BASE_URL:-http://localhost:5011}
+    depends_on:
+      - backend
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
## Summary
- add a docker-compose.yml with backend, frontend and postgres services
- fix `.env.example` that contained leftover diff markers

## Testing
- `npm install` in `frontend`
- `npm test` *(fails: vitest Permission denied)*
- `./mvnw test` *(fails: missing maven wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_6876c52fee3483258abcee3a14611d81